### PR TITLE
Focus to previous node on backspace on empty field.

### DIFF
--- a/lib/flutter_otp_text_field.dart
+++ b/lib/flutter_otp_text_field.dart
@@ -42,6 +42,7 @@ class OtpTextField extends StatefulWidget {
   final Color fillColor;
   final BorderRadius borderRadius;
   final InputDecoration? decoration;
+  final List<TextStyle?> styles;
   final List<TextInputFormatter>? inputFormatters;
   final EdgeInsetsGeometry? contentPadding;
 
@@ -55,6 +56,7 @@ class OtpTextField extends StatefulWidget {
     this.margin = const EdgeInsets.only(right: 8.0),
     this.textStyle,
     this.clearText = false,
+    this.styles = const [],
     this.keyboardType = TextInputType.number,
     this.borderWidth = 2.0,
     this.cursorColor,
@@ -79,10 +81,13 @@ class OtpTextField extends StatefulWidget {
     this.borderRadius = const BorderRadius.all(Radius.circular(4.0)),
     this.inputFormatters,
     this.contentPadding,
-  }) : assert(numberOfFields > 0);
+  })  : assert(numberOfFields > 0),
+        assert(styles.isNotEmpty
+            ? styles.length == numberOfFields
+            : styles.isEmpty);
 
   @override
-  createState() => _OtpTextFieldState();
+  _OtpTextFieldState createState() => _OtpTextFieldState();
 }
 
 class _OtpTextFieldState extends State<OtpTextField> {


### PR DESCRIPTION
Opened a PR from this issue : https://github.com/david-legend/otp_textfield/issues/12.

So basically, you can't listen to backspace on empty textfield ([source](https://github.com/flutter/flutter/issues/14809)) even with this code below it doesnt work (on my machine tho).
```dart
// Listens for backspace key event when textfield is empty. Moves to previous node if possible.
    return RawKeyboardListener(
        focusNode: FocusNode(),
        onKey: (value) {
          if (value.logicalKey.keyLabel == 'Backspace') {
            changeFocusToPreviousNodeWhenTapBackspace();
          }
        },
        child: generateTextFields(context));
```

I make this workaround by making the textField limit to 2 and set an empty character `\u200b` to it. So when user pressed the backspace, it listen to it, and direct the focus to previous textfield.